### PR TITLE
Update PLZ mappings and implement Zahlstelle feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,12 +13,23 @@ const TEAM_COLORS = {
   "4B": "#9370DB", // Violett
 };
 
+const ZAHLSTELLE_MAP = {
+  "2A": "002",
+  "2B": "004",
+  "2C": "005",
+  "3A": "006",
+  "3B": "007",
+  "3C": "008",
+  "4A": "010",
+  "4B": "011"
+};
 
 const plzInput = $("plzInput");
 const hint = $("hint");
 const resultCard = $("resultCard");
 const resultLabel = $("resultLabel");
 const teamText = $("teamText");
+const zahlstelleText = $("zahlstelleText");
 const ravPill = $("ravPill");
 const ortText = $("ortText");
 const countStatus = $("countStatus");
@@ -43,6 +54,15 @@ function showResult(entry, plz){
   const color = TEAM_COLORS[entry.team] || entry.teamColor || "#00e5ff";
   teamText.style.color = color;
   teamText.style.textShadow = `0 0 24px ${color}, 0 18px 60px rgba(0,0,0,0.45)`;
+
+  const zs = ZAHLSTELLE_MAP[entry.team];
+  if (zs) {
+    zahlstelleText.textContent = `Zahlstelle ${zs}`;
+    zahlstelleText.hidden = false;
+  } else {
+    zahlstelleText.hidden = true;
+  }
+
   ravPill.textContent = entry.rav;
 
   const orts = Array.isArray(entry.orte) ? entry.orte : [];

--- a/data/plz-map.json
+++ b/data/plz-map.json
@@ -43,7 +43,7 @@
       "plz": "8003",
       "team": "3C",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "RAV Vulkanstrasse",
       "orte": [
         "Zürich"
       ]
@@ -79,7 +79,7 @@
       "plz": "8008",
       "team": "3C",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "RAV Vulkanstrasse",
       "orte": [
         "Zürich"
       ]
@@ -241,7 +241,7 @@
       "plz": "8037",
       "team": "3C",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "RAV Hardturmstrasse",
       "orte": [
         "Zürich"
       ]
@@ -250,7 +250,7 @@
       "plz": "8038",
       "team": "3C",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "RAV Lagerstrasse",
       "orte": [
         "Zürich"
       ]
@@ -277,7 +277,7 @@
       "plz": "8041",
       "team": "3C",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "RAV Lagerstrasse",
       "orte": [
         "Zürich"
       ]
@@ -905,7 +905,7 @@
       "plz": "8152",
       "team": "4A",
       "teamColor": "#F5DEB3",
-      "rav": "RAV Opfikon-Glattbrugg",
+      "rav": "RAV Nansenstrasse",
       "orte": [
         "Glattbrugg",
         "Glattpark (Opfikon)",
@@ -916,7 +916,7 @@
       "plz": "8153",
       "team": "4A",
       "teamColor": "#F5DEB3",
-      "rav": "RAV Opfikon-Glattbrugg",
+      "rav": "RAV Nansenstrasse",
       "orte": [
         "Rümlang"
       ]
@@ -1236,7 +1236,7 @@
       "plz": "8302",
       "team": "4A",
       "teamColor": "#F5DEB3",
-      "rav": "RAV Opfikon-Glattbrugg",
+      "rav": "RAV Winterthur",
       "orte": [
         "Kloten"
       ]
@@ -1245,7 +1245,7 @@
       "plz": "8303",
       "team": "4A",
       "teamColor": "#F5DEB3",
-      "rav": "RAV Opfikon-Glattbrugg",
+      "rav": "RAV Winterthur",
       "orte": [
         "Bassersdorf"
       ]
@@ -1301,7 +1301,7 @@
       "plz": "8309",
       "team": "4A",
       "teamColor": "#F5DEB3",
-      "rav": "RAV Opfikon-Glattbrugg",
+      "rav": "RAV Winterthur",
       "orte": [
         "Nürensdorf"
       ]

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <section class="card result-card" id="resultCard" hidden>
       <div class="result-label" id="resultLabel">TEAM FÜR PLZ</div>
       <div class="team" id="teamText">—</div>
+      <div class="zahlstelle" id="zahlstelleText" hidden></div>
       <button class="rav-pill" id="ravPill" type="button">—</button>
       <div class="ort" id="ortText"></div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -115,6 +115,13 @@ h1{
   margin: 14px 0 16px;
   text-shadow: 0 18px 60px rgba(0,0,0,0.45);
 }
+.zahlstelle {
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 16px;
+  opacity: 0.9;
+}
 .rav-pill{
   border:1px solid rgba(255,255,255,0.14);
   background: rgba(0,0,0,0.18);


### PR DESCRIPTION
Updates RAV assignments for specific postal codes and introduces a new 'Zahlstelle' feature in the UI that displays the payment office number based on the assigned team.

---
*PR created automatically by Jules for task [17853085236605146917](https://jules.google.com/task/17853085236605146917) started by @adnan-sacipi-0807*