### PR TITLE
Update visual hierarchy for Zahlstelle on result card

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -116,11 +116,10 @@ h1{
   text-shadow: 0 18px 60px rgba(0,0,0,0.45);
 }
 .zahlstelle {
-  font-size: 24px;
-  font-weight: 600;
-  color: var(--text);
+  font-size: 12px;
+  font-weight: normal;
+  color: var(--muted);
   margin-bottom: 16px;
-  opacity: 0.9;
 }
 .rav-pill{
   border:1px solid rgba(255,255,255,0.14);


### PR DESCRIPTION
This change addresses the requested design adjustments for the 'Zahlstelle' element on the result card.

Key changes:
- Decreased font size from 24px to 12px.
- Changed font weight from 600 (bold-ish) to normal.
- Muted the text color to enhance the hierarchy where the team name and RAV are more visually dominant.

---
*PR created automatically by Jules for task [7803617155853269752](https://jules.google.com/task/7803617155853269752) started by @adnan-sacipi-0807*