### PR TITLE
Refine visual hierarchy proportions for RAV and Zahlstelle

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -116,7 +116,7 @@ h1{
   text-shadow: 0 18px 60px rgba(0,0,0,0.45);
 }
 .zahlstelle {
-  font-size: 12px;
+  font-size: 14px;
   font-weight: normal;
   color: var(--muted);
   margin-bottom: 16px;
@@ -127,7 +127,8 @@ h1{
   color: rgba(240,248,255,0.90);
   padding: 16px 20px;
   border-radius: 18px;
-  font-size: 18px;
+  font-size: 20px;
+  font-weight: 500;
   cursor: default;
   min-width: 280px;
   box-shadow: 0 18px 60px rgba(0,0,0,0.30);


### PR DESCRIPTION
Slightly increased the size and weight of the RAV pill text to make it more present, and increased the Zahlstelle font size to 14px while keeping it subtle, softening the visual steps in the hierarchy.