### PR TITLE
Update unused PLZs and handle fallback in app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -101,11 +101,14 @@ function onInput(){
     return;
   }
 
-  const entry = dataIndex.get(plz);
-  if(!entry){
-    setHint("PLZ nicht gefunden.", true);
-    hideResult();
-    return;
+  let entry = dataIndex.get(plz);
+  if(!entry || !entry.team || entry.team === "-"){
+    entry = {
+      team: entry && entry.team ? entry.team : "-",
+      teamColor: "#808080",
+      rav: "Kein RAV zugeteilt",
+      orte: entry && entry.orte ? entry.orte : []
+    };
   }
 
   setHint("");

--- a/data/plz-map.json
+++ b/data/plz-map.json
@@ -140,9 +140,9 @@
     },
     {
       "plz": "8023",
-      "team": "3C",
+      "team": "-",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "Kein RAV zugeteilt",
       "orte": [
         "Zürich"
       ]
@@ -212,9 +212,9 @@
     },
     {
       "plz": "8034",
-      "team": "3C",
+      "team": "-",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "Kein RAV zugeteilt",
       "orte": [
         "Zürich"
       ]
@@ -230,9 +230,9 @@
     },
     {
       "plz": "8036",
-      "team": "3C",
+      "team": "-",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "Kein RAV zugeteilt",
       "orte": [
         "Zürich"
       ]
@@ -257,18 +257,18 @@
     },
     {
       "plz": "8039",
-      "team": "3C",
+      "team": "-",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "Kein RAV zugeteilt",
       "orte": [
         "Zürich"
       ]
     },
     {
       "plz": "8040",
-      "team": "3C",
+      "team": "-",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "Kein RAV zugeteilt",
       "orte": [
         "Zürich"
       ]
@@ -411,18 +411,18 @@
     },
     {
       "plz": "8058",
-      "team": "4A",
+      "team": "-",
       "teamColor": "#F5DEB3",
-      "rav": "RAV Opfikon-Glattbrugg",
+      "rav": "Kein RAV zugeteilt",
       "orte": [
         "Zürich"
       ]
     },
     {
       "plz": "8060",
-      "team": "4A",
+      "team": "-",
       "teamColor": "#F5DEB3",
-      "rav": "RAV Opfikon-Glattbrugg",
+      "rav": "Kein RAV zugeteilt",
       "orte": [
         "Zürich"
       ]
@@ -438,9 +438,9 @@
     },
     {
       "plz": "8063",
-      "team": "3C",
+      "team": "-",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "Kein RAV zugeteilt",
       "orte": [
         "Zürich"
       ]
@@ -573,18 +573,18 @@
     },
     {
       "plz": "8088",
-      "team": "3C",
+      "team": "-",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "Kein RAV zugeteilt",
       "orte": [
         "Zürich"
       ]
     },
     {
       "plz": "8090",
-      "team": "3C",
+      "team": "-",
       "teamColor": "#4169E1",
-      "rav": "RAV Zürich Staffelstrasse",
+      "rav": "Kein RAV zugeteilt",
       "orte": [
         "Zürich"
       ]
@@ -1171,9 +1171,9 @@
     },
     {
       "plz": "8198",
-      "team": "4A",
+      "team": "-",
       "teamColor": "#F5DEB3",
-      "rav": "RAV Opfikon-Glattbrugg",
+      "rav": "Kein RAV zugeteilt",
       "orte": [
         "Rümlang Voice Pub."
       ]


### PR DESCRIPTION
Update unused PLZs and handle fallback in app.js

- Updated data/plz-map.json for specific unused PLZs (8058, 8060, 8198,
  8023, 8034, 8036, 8039, 8040, 8063, 8088, 8090) to have Team '-' and
  RAV 'Kein RAV zugeteilt'.
- Modified app.js onInput() to smoothly handle inputs that are missing from
  the database or unassigned by applying a fallback entry with a neutral grey color.
- Because '-' is not in ZAHLSTELLE_MAP, the 'Zahlstelle' text is automatically hidden.

---
*PR created automatically by Jules for task [8050170065673889009](https://jules.google.com/task/8050170065673889009) started by @adnan-sacipi-0807*